### PR TITLE
Bump react, react-dom, @types/react and @types/react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "devDependencies": {
     "@types/papaparse": "^5.0.3",
-    "@types/react": "^16.9.18",
-    "@types/react-dom": "^16.9.2",
+    "@types/react": "^16.9.34",
+    "@types/react-dom": "^16.9.7",
     "parcel-bundler": "^1.12.4",
     "typescript": "^3.8.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -764,17 +764,17 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
-"@types/react-dom@^16.9.2":
-  version "16.9.2"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.2.tgz#90f9e6c161850be1feb31d2f448121be2a4f3b47"
-  integrity sha512-hgPbBoI1aTSTvZwo8HYw35UaTldW6n2ETLvHAcfcg1FaOuBV3olmyCe5eMpx2WybWMBPv0MdU2t5GOcQhP+3zA==
+"@types/react-dom@^16.9.7":
+  version "16.9.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.7.tgz#60844d48ce252d7b2dccf0c7bb937130e27c0cd2"
+  integrity sha512-GHTYhM8/OwUCf254WO5xqR/aqD3gC9kSTLpopWGpQLpnw23jk44RvMHsyUSEplvRJZdHxhJGMMLF0kCPYHPhQA==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.18":
-  version "16.9.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.18.tgz#7dfb420a780e3740d43563506009834a86ae2af0"
-  integrity sha512-MvjiKX/kUE8o49ipppg49RDZ97p4XfW1WWksp/UlTUSJpisyhzd62pZAMXxAscFLoxfYOflkGANAnGkSeHTFQg==
+"@types/react@*", "@types/react@^16.9.34":
+  version "16.9.34"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.34.tgz#f7d5e331c468f53affed17a8a4d488cd44ea9349"
+  integrity sha512-8AJlYMOfPe1KGLKyHpflCg5z46n0b5DbRfqDksxBLBTUpB75ypDBAO9eCUcjNwE6LCUslwTz00yyG/X9gaVtow==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
@@ -4178,14 +4178,14 @@ rc@^1.2.7:
     strip-json-comments "~2.0.1"
 
 react-dom@^16:
-  version "16.12.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
-  integrity sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==
+  version "16.13.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.0.tgz#cdde54b48eb9e8a0ca1b3dc9943d9bb409b81866"
+  integrity sha512-y09d2c4cG220DzdlFkPTnVvGTszVvNpC73v+AaLGLHbkpy3SSgvYq8x0rNwPJ/Rk/CicTNgk0hbHNw1gMEZAXg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.18.0"
+    scheduler "^0.19.0"
 
 react-is@^16.8.1:
   version "16.9.0"
@@ -4193,9 +4193,9 @@ react-is@^16.8.1:
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
 react@^16:
-  version "16.12.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
-  integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
+  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -4460,10 +4460,10 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-scheduler@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.18.0.tgz#5901ad6659bc1d8f3fdaf36eb7a67b0d6746b1c4"
-  integrity sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==
+scheduler@^0.19.0:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Bumps [react](https://github.com/facebook/react/tree/HEAD/packages/react), [react-dom](https://github.com/facebook/react/tree/HEAD/packages/react-dom), [@types/react](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/react) and [@types/react-dom](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/react-dom). These dependencies needed to be updated together.

Updates `react` from 16.12.0 to 16.13.1
<details>
<summary>Release notes</summary>

*Sourced from [react's releases](https://github.com/facebook/react/releases).*

> ## 16.13.1 (March 19, 2020)
> ### React DOM
> 
> * Fix bug in legacy mode Suspense where effect clean-up functions are not fired. This only affects users who use Suspense for data fetching in legacy mode, which is not technically supported. ([@&#8203;acdlite](https://github.com/acdlite) in [#18238](https://github-redirect.dependabot.com/facebook/react/pull/18238))
> * Revert warning for cross-component updates that happen inside class render lifecycles (`componentWillReceiveProps`, `shouldComponentUpdate`, and so on). ([@&#8203;gaearon](https://github.com/gaearon) in [#18330](https://github-redirect.dependabot.com/facebook/react/pull/18330))
> 
> ## Artifacts
> 
> - react: https://unpkg.com/react@16.13.1/umd/
> - react-art: https://unpkg.com/react-art@16.13.1/umd/
> - react-dom: https://unpkg.com/react-dom@16.13.1/umd/
> - react-is: https://unpkg.com/react-is@16.13.1/umd/
> - react-test-renderer: https://unpkg.com/react-test-renderer@16.13.1/umd/
> - scheduler: https://unpkg.com/scheduler@0.19.1/umd/
> 
> ## 16.13.0 (February 26, 2020)
> ### React 
> 
> * Warn when a string ref is used in a manner that's not amenable to a future codemod ([@&#8203;lunaruan](https://github.com/lunaruan) in [#17864](https://github-redirect.dependabot.com/facebook/react/pull/17864))
> * Deprecate `React.createFactory()` ([@&#8203;trueadm](https://github.com/trueadm) in [#17878](https://github-redirect.dependabot.com/facebook/react/pull/17878))
> 
> ### React DOM
> 
> * Warn when changes in `style` may cause an unexpected collision ([@&#8203;sophiebits](https://github.com/sophiebits) in [#14181](https://github-redirect.dependabot.com/facebook/react/pull/14181), [#18002](https://github-redirect.dependabot.com/facebook/react/pull/18002))
> * Warn when a function component is updated during another component's render phase ([@&#8203;acdlite]((https://github.com/acdlite)) in [#17099](https://github-redirect.dependabot.com/facebook/react/pull/17099))
> * Deprecate `unstable_createPortal` ([@&#8203;trueadm](https://github.com/trueadm) in [#17880](https://github-redirect.dependabot.com/facebook/react/pull/17880))
> * Fix `onMouseEnter` being fired on disabled buttons ([@&#8203;AlfredoGJ](https://github.com/AlfredoGJ) in [#17675](https://github-redirect.dependabot.com/facebook/react/pull/17675))
> * Call `shouldComponentUpdate` twice when developing in `StrictMode` ([@&#8203;bvaughn](https://github.com/bvaughn) in [#17942](https://github-redirect.dependabot.com/facebook/react/pull/17942))
> * Add `version` property to ReactDOM ([@&#8203;ealush](https://github.com/ealush) in [#15780](https://github-redirect.dependabot.com/facebook/react/pull/15780))
> * Don't call `toString()` of `dangerouslySetInnerHTML` ([@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17773](https://github-redirect.dependabot.com/facebook/react/pull/17773))
> * Show component stacks in more warnings ([@&#8203;gaearon](https://github.com/gaearon) in [#17922](https://github-redirect.dependabot.com/facebook/react/pull/17922), [#17586](https://github-redirect.dependabot.com/facebook/react/pull/17586))
> 
> ### Concurrent Mode (Experimental)
> 
> * Warn for problematic usages of `ReactDOM.createRoot()` ([@&#8203;trueadm](https://github.com/trueadm) in [#17937](https://github-redirect.dependabot.com/facebook/react/pull/17937))
> * Remove `ReactDOM.createRoot()` callback params and added warnings on usage ([@&#8203;bvaughn](https://github.com/bvaughn) in [#17916](https://github-redirect.dependabot.com/facebook/react/pull/17916))
> * Don't group Idle/Offscreen work with other work ([@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17456](https://github-redirect.dependabot.com/facebook/react/pull/17456))
> * Adjust `SuspenseList` CPU bound heuristic ([@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17455](https://github-redirect.dependabot.com/facebook/react/pull/17455))
> * Add missing event plugin priorities ([@&#8203;trueadm](https://github.com/trueadm) in [#17914](https://github-redirect.dependabot.com/facebook/react/pull/17914))
> * Fix `isPending` only being true when transitioning from inside an input event ([@&#8203;acdlite](https://github.com/acdlite) in [#17382](https://github-redirect.dependabot.com/facebook/react/pull/17382))
> * Fix `React.memo` components dropping updates when interrupted by a higher priority update ([@&#8203;acdlite]((https://github.com/acdlite)) in [#18091](https://github-redirect.dependabot.com/facebook/react/pull/18091)) 
> * Don't warn when suspending at the wrong priority ([@&#8203;gaearon](https://github.com/gaearon) in [#17971](https://github-redirect.dependabot.com/facebook/react/pull/17971))
> * Fix a bug with rebasing updates ([@&#8203;acdlite](https://github.com/acdlite) and [@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17560](https://github-redirect.dependabot.com/facebook/react/pull/17560), [#17510](https://github-redirect.dependabot.com/facebook/react/pull/17510), [#17483](https://github-redirect.dependabot.com/facebook/react/pull/17483), [#17480](https://github-redirect.dependabot.com/facebook/react/pull/17480))
> 
> ## Artifacts
> 
> - react: https://unpkg.com/react@16.13.0/umd/
> - react-art: https://unpkg.com/react-art@16.13.0/umd/
> - react-dom: https://unpkg.com/react-dom@16.13.0/umd/
> - react-is: https://unpkg.com/react-is@16.13.0/umd/
></tr></table> ... (truncated)
</details>
<details>
<summary>Changelog</summary>

*Sourced from [react's changelog](https://github.com/facebook/react/blob/master/CHANGELOG.md).*

> ## 16.13.1 (March 19, 2020)
> 
> ### React DOM
> 
> * Fix bug in legacy mode Suspense where effect clean-up functions are not fired. This only affects users who use Suspense for data fetching in legacy mode, which is not technically supported. ([@&#8203;acdlite](https://github.com/acdlite) in [#18238](https://github-redirect.dependabot.com/facebook/react/pull/18238))
> * Revert warning for cross-component updates that happen inside class render lifecycles (`componentWillReceiveProps`, `shouldComponentUpdate`, and so on). ([@&#8203;gaearon](https://github.com/gaearon) in [#18330](https://github-redirect.dependabot.com/facebook/react/pull/18330))
> 
> ## 16.13.0 (February 26, 2020)
> 
> ### React
> 
> * Warn when a string ref is used in a manner that's not amenable to a future codemod ([@&#8203;lunaruan](https://github.com/lunaruan) in [#17864](https://github-redirect.dependabot.com/facebook/react/pull/17864))
> * Deprecate `React.createFactory()` ([@&#8203;trueadm](https://github.com/trueadm) in [#17878](https://github-redirect.dependabot.com/facebook/react/pull/17878))
> 
> ### React DOM
> 
> * Warn when changes in `style` may cause an unexpected collision ([@&#8203;sophiebits](https://github.com/sophiebits) in [#14181](https://github-redirect.dependabot.com/facebook/react/pull/14181), [#18002](https://github-redirect.dependabot.com/facebook/react/pull/18002))
> * Warn when a function component is updated during another component's render phase ([@&#8203;acdlite](https://github.com/acdlite) in [#17099](https://github-redirect.dependabot.com/facebook/react/pull/17099))
> * Deprecate `unstable_createPortal` ([@&#8203;trueadm](https://github.com/trueadm) in [#17880](https://github-redirect.dependabot.com/facebook/react/pull/17880))
> * Fix `onMouseEnter` being fired on disabled buttons ([@&#8203;AlfredoGJ](https://github.com/AlfredoGJ) in [#17675](https://github-redirect.dependabot.com/facebook/react/pull/17675))
> * Call `shouldComponentUpdate` twice when developing in `StrictMode` ([@&#8203;bvaughn](https://github.com/bvaughn) in [#17942](https://github-redirect.dependabot.com/facebook/react/pull/17942))
> * Add `version` property to ReactDOM ([@&#8203;ealush](https://github.com/ealush) in [#15780](https://github-redirect.dependabot.com/facebook/react/pull/15780))
> * Don't call `toString()` of `dangerouslySetInnerHTML` ([@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17773](https://github-redirect.dependabot.com/facebook/react/pull/17773))
> * Show component stacks in more warnings ([@&#8203;gaearon](https://github.com/gaearon) in [#17922](https://github-redirect.dependabot.com/facebook/react/pull/17922), [#17586](https://github-redirect.dependabot.com/facebook/react/pull/17586))
> 
> ### Concurrent Mode (Experimental)
> 
> * Warn for problematic usages of `ReactDOM.createRoot()` ([@&#8203;trueadm](https://github.com/trueadm) in [#17937](https://github-redirect.dependabot.com/facebook/react/pull/17937))
> * Remove `ReactDOM.createRoot()` callback params and added warnings on usage ([@&#8203;bvaughn](https://github.com/bvaughn) in [#17916](https://github-redirect.dependabot.com/facebook/react/pull/17916))
> * Don't group Idle/Offscreen work with other work ([@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17456](https://github-redirect.dependabot.com/facebook/react/pull/17456))
> * Adjust `SuspenseList` CPU bound heuristic ([@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17455](https://github-redirect.dependabot.com/facebook/react/pull/17455))
> * Add missing event plugin priorities ([@&#8203;trueadm](https://github.com/trueadm) in [#17914](https://github-redirect.dependabot.com/facebook/react/pull/17914))
> * Fix `isPending` only being true when transitioning from inside an input event ([@&#8203;acdlite](https://github.com/acdlite) in [#17382](https://github-redirect.dependabot.com/facebook/react/pull/17382))
> * Fix `React.memo` components dropping updates when interrupted by a higher priority update ([@&#8203;acdlite]((https://github.com/acdlite)) in [#18091](https://github-redirect.dependabot.com/facebook/react/pull/18091))
> * Don't warn when suspending at the wrong priority ([@&#8203;gaearon](https://github.com/gaearon) in [#17971](https://github-redirect.dependabot.com/facebook/react/pull/17971))
> * Fix a bug with rebasing updates ([@&#8203;acdlite](https://github.com/acdlite) and [@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17560](https://github-redirect.dependabot.com/facebook/react/pull/17560), [#17510](https://github-redirect.dependabot.com/facebook/react/pull/17510), [#17483](https://github-redirect.dependabot.com/facebook/react/pull/17483), [#17480](https://github-redirect.dependabot.com/facebook/react/pull/17480))
</details>
<details>
<summary>Commits</summary>

- [`8e13e77`](https://github.com/facebook/react/commit/8e13e770e39a6fc634a87b5d5144ec1e54000a0c) Remove /testing entry point from 'react' package ([#18137](https://github.com/facebook/react/tree/HEAD/packages/react/issues/18137))
- [`60016c4`](https://github.com/facebook/react/commit/60016c448bb7d19fc989acd05dda5aca2e124381) Export React as Named Exports instead of CommonJS ([#18106](https://github.com/facebook/react/tree/HEAD/packages/react/issues/18106))
- [`65bbda7`](https://github.com/facebook/react/commit/65bbda7f169394005252b46a5992ece5a2ffadad) Rename Chunks API to Blocks ([#18086](https://github.com/facebook/react/tree/HEAD/packages/react/issues/18086))
- [`b789060`](https://github.com/facebook/react/commit/b789060dca314f052d856cab509569cf41020cd5) Feature Flag for React.jsx` "spreading a key to jsx" warning ([#18074](https://github.com/facebook/react/tree/HEAD/packages/react/issues/18074))
- [`2d6be75`](https://github.com/facebook/react/commit/2d6be757df86177ca8590bf7c361d6c910640895) [Native] Delete NativeComponent and NativeMethodsMixin ([#18036](https://github.com/facebook/react/tree/HEAD/packages/react/issues/18036))
- [`c55c34e`](https://github.com/facebook/react/commit/c55c34e46a6d8148afb78594d14f4675f9346900) Move React Map child check to behind flags or __DEV__ ([#17995](https://github.com/facebook/react/tree/HEAD/packages/react/issues/17995))
- [`256d78d`](https://github.com/facebook/react/commit/256d78d11f1c7da749914a8b2d35b2974a54b0f2) Add feature flag for removing children Map support ([#17990](https://github.com/facebook/react/tree/HEAD/packages/react/issues/17990))
- [`3e9251d`](https://github.com/facebook/react/commit/3e9251d605692e6db6103e4fca9771ac30a62247) make testing builds for React/ReactDOM ([#17915](https://github.com/facebook/react/tree/HEAD/packages/react/issues/17915))
- [`6ae2c33`](https://github.com/facebook/react/commit/6ae2c33a759e8f44622795603c84da9a2ebddf43) StrictMode should call sCU twice in DEV ([#17942](https://github.com/facebook/react/tree/HEAD/packages/react/issues/17942))
- [`57333ca`](https://github.com/facebook/react/commit/57333ca33a0619ff2334e4eb19139b4c7e9830f7) Show first component stack in context warning ([#17922](https://github.com/facebook/react/tree/HEAD/packages/react/issues/17922))
- Additional commits viewable in [compare view](https://github.com/facebook/react/commits/v16.13.1/packages/react)
</details>
<br />

Updates `react-dom` from 16.12.0 to 16.13.0
<details>
<summary>Release notes</summary>

*Sourced from [react-dom's releases](https://github.com/facebook/react/releases).*

> ## 16.13.0 (February 26, 2020)
> ### React 
> 
> * Warn when a string ref is used in a manner that's not amenable to a future codemod ([@&#8203;lunaruan](https://github.com/lunaruan) in [#17864](https://github-redirect.dependabot.com/facebook/react/pull/17864))
> * Deprecate `React.createFactory()` ([@&#8203;trueadm](https://github.com/trueadm) in [#17878](https://github-redirect.dependabot.com/facebook/react/pull/17878))
> 
> ### React DOM
> 
> * Warn when changes in `style` may cause an unexpected collision ([@&#8203;sophiebits](https://github.com/sophiebits) in [#14181](https://github-redirect.dependabot.com/facebook/react/pull/14181), [#18002](https://github-redirect.dependabot.com/facebook/react/pull/18002))
> * Warn when a function component is updated during another component's render phase ([@&#8203;acdlite]((https://github.com/acdlite)) in [#17099](https://github-redirect.dependabot.com/facebook/react/pull/17099))
> * Deprecate `unstable_createPortal` ([@&#8203;trueadm](https://github.com/trueadm) in [#17880](https://github-redirect.dependabot.com/facebook/react/pull/17880))
> * Fix `onMouseEnter` being fired on disabled buttons ([@&#8203;AlfredoGJ](https://github.com/AlfredoGJ) in [#17675](https://github-redirect.dependabot.com/facebook/react/pull/17675))
> * Call `shouldComponentUpdate` twice when developing in `StrictMode` ([@&#8203;bvaughn](https://github.com/bvaughn) in [#17942](https://github-redirect.dependabot.com/facebook/react/pull/17942))
> * Add `version` property to ReactDOM ([@&#8203;ealush](https://github.com/ealush) in [#15780](https://github-redirect.dependabot.com/facebook/react/pull/15780))
> * Don't call `toString()` of `dangerouslySetInnerHTML` ([@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17773](https://github-redirect.dependabot.com/facebook/react/pull/17773))
> * Show component stacks in more warnings ([@&#8203;gaearon](https://github.com/gaearon) in [#17922](https://github-redirect.dependabot.com/facebook/react/pull/17922), [#17586](https://github-redirect.dependabot.com/facebook/react/pull/17586))
> 
> ### Concurrent Mode (Experimental)
> 
> * Warn for problematic usages of `ReactDOM.createRoot()` ([@&#8203;trueadm](https://github.com/trueadm) in [#17937](https://github-redirect.dependabot.com/facebook/react/pull/17937))
> * Remove `ReactDOM.createRoot()` callback params and added warnings on usage ([@&#8203;bvaughn](https://github.com/bvaughn) in [#17916](https://github-redirect.dependabot.com/facebook/react/pull/17916))
> * Don't group Idle/Offscreen work with other work ([@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17456](https://github-redirect.dependabot.com/facebook/react/pull/17456))
> * Adjust `SuspenseList` CPU bound heuristic ([@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17455](https://github-redirect.dependabot.com/facebook/react/pull/17455))
> * Add missing event plugin priorities ([@&#8203;trueadm](https://github.com/trueadm) in [#17914](https://github-redirect.dependabot.com/facebook/react/pull/17914))
> * Fix `isPending` only being true when transitioning from inside an input event ([@&#8203;acdlite](https://github.com/acdlite) in [#17382](https://github-redirect.dependabot.com/facebook/react/pull/17382))
> * Fix `React.memo` components dropping updates when interrupted by a higher priority update ([@&#8203;acdlite]((https://github.com/acdlite)) in [#18091](https://github-redirect.dependabot.com/facebook/react/pull/18091)) 
> * Don't warn when suspending at the wrong priority ([@&#8203;gaearon](https://github.com/gaearon) in [#17971](https://github-redirect.dependabot.com/facebook/react/pull/17971))
> * Fix a bug with rebasing updates ([@&#8203;acdlite](https://github.com/acdlite) and [@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17560](https://github-redirect.dependabot.com/facebook/react/pull/17560), [#17510](https://github-redirect.dependabot.com/facebook/react/pull/17510), [#17483](https://github-redirect.dependabot.com/facebook/react/pull/17483), [#17480](https://github-redirect.dependabot.com/facebook/react/pull/17480))
> 
> ## Artifacts
> 
> - react: https://unpkg.com/react@16.13.0/umd/
> - react-art: https://unpkg.com/react-art@16.13.0/umd/
> - react-dom: https://unpkg.com/react-dom@16.13.0/umd/
> - react-is: https://unpkg.com/react-is@16.13.0/umd/
> - react-test-renderer: https://unpkg.com/react-test-renderer@16.13.0/umd/
> - scheduler: https://unpkg.com/scheduler@0.19.0/umd/
</details>
<details>
<summary>Changelog</summary>

*Sourced from [react-dom's changelog](https://github.com/facebook/react/blob/master/CHANGELOG.md).*

> ## 16.13.0 (February 26, 2020)
> 
> ### React
> 
> * Warn when a string ref is used in a manner that's not amenable to a future codemod ([@&#8203;lunaruan](https://github.com/lunaruan) in [#17864](https://github-redirect.dependabot.com/facebook/react/pull/17864))
> * Deprecate `React.createFactory()` ([@&#8203;trueadm](https://github.com/trueadm) in [#17878](https://github-redirect.dependabot.com/facebook/react/pull/17878))
> 
> ### React DOM
> 
> * Warn when changes in `style` may cause an unexpected collision ([@&#8203;sophiebits](https://github.com/sophiebits) in [#14181](https://github-redirect.dependabot.com/facebook/react/pull/14181), [#18002](https://github-redirect.dependabot.com/facebook/react/pull/18002))
> * Warn when a function component is updated during another component's render phase ([@&#8203;acdlite](https://github.com/acdlite) in [#17099](https://github-redirect.dependabot.com/facebook/react/pull/17099))
> * Deprecate `unstable_createPortal` ([@&#8203;trueadm](https://github.com/trueadm) in [#17880](https://github-redirect.dependabot.com/facebook/react/pull/17880))
> * Fix `onMouseEnter` being fired on disabled buttons ([@&#8203;AlfredoGJ](https://github.com/AlfredoGJ) in [#17675](https://github-redirect.dependabot.com/facebook/react/pull/17675))
> * Call `shouldComponentUpdate` twice when developing in `StrictMode` ([@&#8203;bvaughn](https://github.com/bvaughn) in [#17942](https://github-redirect.dependabot.com/facebook/react/pull/17942))
> * Add `version` property to ReactDOM ([@&#8203;ealush](https://github.com/ealush) in [#15780](https://github-redirect.dependabot.com/facebook/react/pull/15780))
> * Don't call `toString()` of `dangerouslySetInnerHTML` ([@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17773](https://github-redirect.dependabot.com/facebook/react/pull/17773))
> * Show component stacks in more warnings ([@&#8203;gaearon](https://github.com/gaearon) in [#17922](https://github-redirect.dependabot.com/facebook/react/pull/17922), [#17586](https://github-redirect.dependabot.com/facebook/react/pull/17586))
> 
> ### Concurrent Mode (Experimental)
> 
> * Warn for problematic usages of `ReactDOM.createRoot()` ([@&#8203;trueadm](https://github.com/trueadm) in [#17937](https://github-redirect.dependabot.com/facebook/react/pull/17937))
> * Remove `ReactDOM.createRoot()` callback params and added warnings on usage ([@&#8203;bvaughn](https://github.com/bvaughn) in [#17916](https://github-redirect.dependabot.com/facebook/react/pull/17916))
> * Don't group Idle/Offscreen work with other work ([@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17456](https://github-redirect.dependabot.com/facebook/react/pull/17456))
> * Adjust `SuspenseList` CPU bound heuristic ([@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17455](https://github-redirect.dependabot.com/facebook/react/pull/17455))
> * Add missing event plugin priorities ([@&#8203;trueadm](https://github.com/trueadm) in [#17914](https://github-redirect.dependabot.com/facebook/react/pull/17914))
> * Fix `isPending` only being true when transitioning from inside an input event ([@&#8203;acdlite](https://github.com/acdlite) in [#17382](https://github-redirect.dependabot.com/facebook/react/pull/17382))
> * Fix `React.memo` components dropping updates when interrupted by a higher priority update ([@&#8203;acdlite]((https://github.com/acdlite)) in [#18091](https://github-redirect.dependabot.com/facebook/react/pull/18091))
> * Don't warn when suspending at the wrong priority ([@&#8203;gaearon](https://github.com/gaearon) in [#17971](https://github-redirect.dependabot.com/facebook/react/pull/17971))
> * Fix a bug with rebasing updates ([@&#8203;acdlite](https://github.com/acdlite) and [@&#8203;sebmarkbage](https://github.com/sebmarkbage) in [#17560](https://github-redirect.dependabot.com/facebook/react/pull/17560), [#17510](https://github-redirect.dependabot.com/facebook/react/pull/17510), [#17483](https://github-redirect.dependabot.com/facebook/react/pull/17483), [#17480](https://github-redirect.dependabot.com/facebook/react/pull/17480))
</details>
<details>
<summary>Commits</summary>

- [`c1c5499`](https://github.com/facebook/react/commit/c1c5499cc3fd179004911b3391a55de1af4de037) update version numbers for 16.13 ([#18143](https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/18143))
- [`f3ecd56`](https://github.com/facebook/react/commit/f3ecd56beacd4a2849a1bac4faab5d41b7ad758b) Fixed a spelling mistake in a comment. ([#18119](https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/18119))
- [`60016c4`](https://github.com/facebook/react/commit/60016c448bb7d19fc989acd05dda5aca2e124381) Export React as Named Exports instead of CommonJS ([#18106](https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/18106))
- [`ccab494`](https://github.com/facebook/react/commit/ccab49473897aacae43bb4d55c1061065892403c) Move type DOMContainer to HostConfig ([#18112](https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/18112))
- [`0934879`](https://github.com/facebook/react/commit/09348798a912c8682e57c35842aa7a007e13fdb9) Codemod to import * as React from "react"; ([#18102](https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/18102))
- [`2c4221c`](https://github.com/facebook/react/commit/2c4221ce8bc5765bfddc4b32af4af602077a4a3e) Change string refs in function component message ([#18031](https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/18031))
- [`3f85d53`](https://github.com/facebook/react/commit/3f85d53ca6f2af8a711daae6322e6bdda862f660) Further pre-requisite changes to plugin event system ([#18083](https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/18083))
- [`1000f61`](https://github.com/facebook/react/commit/1000f6135efba4f8d8ebffedeb7b472f532a8475) Add container to event listener signature ([#18075](https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/18075))
- [`4912ba3`](https://github.com/facebook/react/commit/4912ba31e3dcc8d08f5b16ae38b38d74da85ea21) Add modern event system flag + rename legacy plugin module ([#18073](https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/18073))
- [`1a6d817`](https://github.com/facebook/react/commit/1a6d8179b6dd427fdf7ee50d5ac45ae5a40979eb) [react-interactions] Ensure onBeforeBlur fires for hideInstance ([#18064](https://github.com/facebook/react/tree/HEAD/packages/react-dom/issues/18064))
- Additional commits viewable in [compare view](https://github.com/facebook/react/commits/v16.13.0/packages/react-dom)
</details>
<br />

Updates `@types/react` from 16.9.18 to 16.9.34
<details>
<summary>Commits</summary>

- See full diff in [compare view](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/react)
</details>
<br />

Updates `@types/react-dom` from 16.9.2 to 16.9.7
<details>
<summary>Commits</summary>

- See full diff in [compare view](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/react-dom)
</details>
<br />